### PR TITLE
Fix: Add Vercel routing for /game endpoint

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "rewrites": [
+    { "source": "/game", "destination": "/game.html" },
+    { "source": "/", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `vercel.json` configuration to fix 404 error on `/game` route
- Configures rewrites to properly route `/game` to `/game.html` in production

## Problem
The `/game` endpoint was returning 404 on Vercel deployment because the routing wasn't configured.

## Solution
Created `vercel.json` with rewrite rules to handle clean URLs for both `/game` and `/` routes.

## Test plan
- [ ] Deploy to Vercel
- [ ] Verify `https://codekid-ai-chess-online.vercel.app/game` loads successfully
- [ ] Verify home page still works at root path

🤖 Generated with [Claude Code](https://claude.com/claude-code)