### PR TITLE
fix: Improve game mode modal styling and readability

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -734,21 +734,23 @@ body.game-page {
 .game-mode-buttons {
     display: flex;
     flex-direction: column;
-    gap: 20px;
+    gap: 12px;
 }
 
 .mode-btn {
     background: linear-gradient(135deg, #ffffff 0%, #f8f9fa 100%);
     color: #2c3e50;
     border: none;
-    padding: 20px 30px;
-    font-size: 20px;
+    padding: 10px 15px;
+    font-size: 14px;
     font-weight: bold;
-    border-radius: 15px;
+    border-radius: 10px;
     cursor: pointer;
     transition: all 0.3s ease;
     box-shadow: 0 8px 25px rgba(255, 255, 255, 0.2);
-    border: 3px solid transparent;
+    border: 2px solid transparent;
+    width: 350px;
+    margin: 0 auto;
 }
 
 .mode-btn:hover {
@@ -758,14 +760,17 @@ body.game-page {
 }
 
 .mode-btn .mode-title {
-    font-size: 22px;
-    margin-bottom: 5px;
+    font-size: 16px;
+    margin-bottom: 4px;
+    color: #2c3e50;
 }
 
 .mode-btn .mode-description {
-    font-size: 14px;
+    font-size: 13px;
     color: #7f8c8d;
     font-weight: normal;
+    white-space: normal;
+    word-wrap: break-word;
 }
 
 @keyframes modalAppear {


### PR DESCRIPTION
## Summary
Improved the game mode selection modal styling for better readability and more compact layout.

## Changes

### Button Styling
- Reduced button padding from `20px 30px` to `10px 15px`
- Set fixed width of `350px` for all buttons to ensure consistency
- Updated border width from `3px` to `2px`
- Reduced border radius from `15px` to `10px`

### Text Sizing
- Mode title font size: `22px` → `16px`
- Mode description font size: `14px` → `13px`
- Added explicit dark color (`#2c3e50`) to mode titles for visibility
- Reduced title margin-bottom from `5px` to `4px`

### Layout
- Reduced gap between buttons from `20px` to `12px`
- Added text wrapping for long descriptions (`white-space: normal`, `word-wrap: break-word`)
- Centered buttons with `margin: 0 auto`

## Visual Improvements
- More compact and clean modal appearance
- Consistent button widths prevent layout shifts
- Long descriptions wrap properly instead of overflowing
- Better readability with appropriately sized text

## Files Modified
- ✅ [src/styles/style.css](src/styles/style.css) - Game mode modal button styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)