### PR TITLE
fix: Prevent king from illegally moving 2 squares

### DIFF
--- a/src/utils/chess/moveRules.ts
+++ b/src/utils/chess/moveRules.ts
@@ -146,16 +146,8 @@ export function isValidKingMove(
   const colDiff = Math.abs(toCol - fromCol)
 
   // Normal king move (1 square in any direction)
-  if (rowDiff <= 1 && colDiff <= 1) {
-    return true
-  }
-
-  // Castling (2 squares horizontally) - further validation in isValidCastling
-  if (rowDiff === 0 && colDiff === 2) {
-    return true
-  }
-
-  return false
+  // Note: Castling (2 squares) is validated separately in isValidCastling
+  return rowDiff <= 1 && colDiff <= 1
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
Fixed a critical bug where the king could move 2 squares horizontally even when not castling, allowing it to jump through blocking pieces.

## Bug Description
The king was able to make illegal moves like f6 → d6 (2 squares) even when:
- A piece was blocking the path (e.g., pawn on e6)
- The king had already moved (not eligible for castling)
- It wasn't a valid castling scenario

## Root Cause
The `isValidKingMove()` function in [moveRules.ts](src/utils/chess/moveRules.ts) had a bug where it returned `true` for any 2-square horizontal move:

```typescript
// Castling (2 squares horizontally) - further validation in isValidCastling
if (rowDiff === 0 && colDiff === 2) {
  return true  // ❌ This allowed illegal 2-square moves!
}
```

This bypassed proper castling validation and allowed the king to jump 2 squares regardless of game state.

## Fix
- Removed the premature return for 2-square moves
- King is now correctly restricted to 1 square in any direction
- Castling still works properly through `isValidCastling()` validation in the move execution logic

```typescript
export function isValidKingMove(...) {
  const rowDiff = Math.abs(toRow - fromRow)
  const colDiff = Math.abs(toCol - fromCol)
  
  // Normal king move (1 square in any direction)
  // Note: Castling (2 squares) is validated separately in isValidCastling
  return rowDiff <= 1 && colDiff <= 1
}
```

## Testing
- ✅ King can no longer move 2 squares unless castling
- ✅ King cannot jump through pieces
- ✅ Castling still works when king/rook haven't moved and path is clear
- ✅ Normal 1-square king moves work in all directions

## Files Modified
- ✅ [src/utils/chess/moveRules.ts](src/utils/chess/moveRules.ts) - Fixed king movement validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)